### PR TITLE
HostInfo class __ne__ method returns not __eq__

### DIFF
--- a/rb/cluster.py
+++ b/rb/cluster.py
@@ -32,7 +32,7 @@ class HostInfo(object):
         rv = self.__eq__(other)
         if rv is NotImplemented:
             return NotImplemented
-        return rv
+        return not rv
 
     def __hash__(self):
         return self.host_id


### PR DESCRIPTION
As is the `__ne__` method of `HostInfo` is only returning `__eq__`.  This commit sets `__ne__` to return `not __eq__` (returns the negation of `__eq__`).