### PR TITLE
Fixed auto_batch_commands duplication

### DIFF
--- a/rb/clients.py
+++ b/rb/clients.py
@@ -545,11 +545,10 @@ class LocalClient(BaseClient):
     host.
     """
 
-    def __init__(self, cluster, connection_pool=None, **kwargs):
+    def __init__(self, connection_pool=None, **kwargs):
         if connection_pool is None:
             raise TypeError('The local client needs a connection pool')
-        BaseClient.__init__(self, cluster, connection_pool=connection_pool,
-                            **kwargs)
+        BaseClient.__init__(self, connection_pool=connection_pool, **kwargs)
 
 
 class MapManager(object):

--- a/rb/clients.py
+++ b/rb/clients.py
@@ -99,7 +99,7 @@ def auto_batch_commands(commands):
         if command_name not in AUTO_BATCH_COMMANDS:
             if pending_batch:
                 yield merge_batch(*pending_batch)
-                None
+                pending_batch = None
             yield command_name, args, promise
             continue
 

--- a/rb/cluster.py
+++ b/rb/cluster.py
@@ -216,8 +216,7 @@ class Cluster(object):
         works like a regular Python redis client and returns results
         immediately.
         """
-        return LocalClient(
-            self, connection_pool=self.get_pool_for_host(host_id))
+        return LocalClient(connection_pool=self.get_pool_for_host(host_id))
 
     def get_local_client_for_key(self, key):
         """Similar to :meth:`get_local_client_for_key` but returns the


### PR DESCRIPTION
- Do not pass cluster to LocalClient
- Fixed auto_batch_commands

The auto_batch_commands problem can be easily produced by:

    from rb import Cluster

    cluster = Cluster(hosts={
        0: {},
    })

    with cluster.map() as client:
        client.mget('1', '2')
        client.hget('a', 'b')
        client.mget('3', '4')  # batched with '1' and '2', because we forget to clean