### PR TITLE
Fixed partition router to get the right routed host

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Rb Changelog
 ============
 
+Version 1.3.2
+-------------
+
+- Fixed partition router to get the right routed host.
+
 Version 1.3.1
 -------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 1.3.2
 -------------
 
 - Fixed partition router to get the right routed host.
+- Make host_defaults of cluster work.
 
 Version 1.3.1
 -------------

--- a/rb/cluster.py
+++ b/rb/cluster.py
@@ -44,9 +44,15 @@ class HostInfo(object):
         )
 
 
-def _iter_hosts(iterable):
+def _iter_hosts(iterable, host_defaults):
     if isinstance(iterable, dict):
         iterable = iterable.iteritems()
+    if host_defaults:
+        # in case host id is set accidentally
+        try:
+            del host_defaults['host_id']
+        except KeyError:
+            pass
     for item in iterable:
         if isinstance(item, tuple):
             host_id, cfg = item
@@ -54,6 +60,9 @@ def _iter_hosts(iterable):
             cfg['host_id'] = host_id
         else:
             cfg = item
+        if host_defaults:
+            for k, v in host_defaults.iteritems():
+                cfg.setdefault(k, v)
         yield cfg
 
 
@@ -99,7 +108,7 @@ class Cluster(object):
         self.hosts = {}
         self._hosts_age = 0
         self.host_defaults = host_defaults or {}
-        for host_config in _iter_hosts(hosts):
+        for host_config in _iter_hosts(hosts, self.host_defaults):
             self.add_host(**host_config)
 
     def add_host(self, host_id=None, host='localhost', port=6379,

--- a/rb/router.py
+++ b/rb/router.py
@@ -105,9 +105,16 @@ class PartitionRouter(BaseRouter):
     single nodes based on a simple ``crc32 % node_count`` setup.
     """
 
+    def __init__(self, cluster):
+        BaseRouter.__init__(self, cluster)
+        self._hosts = sorted(self.cluster.hosts.values(),
+                             key=lambda host: host.host_id)
+
     def get_host_for_key(self, key):
         if isinstance(key, unicode):
             k = key.encode('utf-8')
         else:
             k = str(key)
-        return crc32(k) % len(self.cluster.hosts)
+        pos = crc32(k) % len(self._hosts)
+        host = self._hosts[pos]
+        return host.host_id

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -9,6 +9,8 @@ def test_basic_interface():
         0: {'db': 0},
         1: {'db': 2},
         2: {'db': 4, 'host': '127.0.0.1'},
+    }, host_defaults={
+        'password': 'pass',
     })
 
     assert len(cluster.hosts) == 3
@@ -17,16 +19,19 @@ def test_basic_interface():
     assert cluster.hosts[0].db == 0
     assert cluster.hosts[0].host == 'localhost'
     assert cluster.hosts[0].port == 6379
+    assert cluster.hosts[0].password == 'pass'
 
     assert cluster.hosts[1].host_id == 1
     assert cluster.hosts[1].db == 2
     assert cluster.hosts[1].host == 'localhost'
     assert cluster.hosts[1].port == 6379
+    assert cluster.hosts[1].password == 'pass'
 
     assert cluster.hosts[2].host_id == 2
     assert cluster.hosts[2].db == 4
     assert cluster.hosts[2].host == '127.0.0.1'
     assert cluster.hosts[2].port == 6379
+    assert cluster.hosts[2].password == 'pass'
 
 
 def test_router_access():


### PR DESCRIPTION
- Fixed partition router to get the right routed host
- Make host_defaults of cluster work

Partition router only works right when you use zero-based sequence for host ids.