### PR TITLE
Detect dead connections on pool checkout.

### DIFF
--- a/rb/poll.py
+++ b/rb/poll.py
@@ -1,4 +1,7 @@
+import fcntl
+import array
 import select
+import termios
 
 
 class BasePoller(object):
@@ -157,13 +160,41 @@ class EpollPoller(BasePoller):
         return rv
 
 
-def is_closed(f):
-    poller = poll()
-    poller.register(None, f)
-    for _, event in poller.poll(0.0):
+def _is_closed_select(f):
+    rlist, wlist, _ = select.select([f], [f], [], 0.0)
+    if not rlist and not wlist:
+        return False
+    buf = array.array('i', [0])
+    fcntl.ioctl(f.fileno(), termios.FIONREAD, buf)
+    return buf[0] == 0
+
+
+def _is_closed_poll(f):
+    poll = select.poll()
+    poll.register(f.fileno(), select.POLLHUP)
+    for _, event in poll.poll(0.0):
         if event == 'close':
             return True
     return False
+
+
+def _is_closed_kqueue(f):
+    kqueue = select.kqueue()
+    event = select.kevent(
+        f.fileno(), filter=select.KQ_FILTER_READ,
+        flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE)
+    for event in kqueue.control([event], 128, 0.0):
+        if event.flags & select.KQ_EV_EOF:
+            return True
+    return False
+
+
+def is_closed(f):
+    if KQueuePoller.is_available:
+        return _is_closed_kqueue(f)
+    if PollPoller.is_available:
+        return _is_closed_poll(f)
+    return _is_closed_select(f)
 
 
 available_pollers = [poll for poll in [KQueuePoller, PollPoller,

--- a/rb/poll.py
+++ b/rb/poll.py
@@ -157,6 +157,15 @@ class EpollPoller(BasePoller):
         return rv
 
 
+def is_closed(f):
+    poller = poll()
+    poller.register(None, f)
+    for _, event in poller.poll(0.0):
+        if event == 'close':
+            return True
+    return False
+
+
 available_pollers = [poll for poll in [KQueuePoller, PollPoller,
                                        EpollPoller, SelectPoller]
                      if poll.is_available]


### PR DESCRIPTION
This solves the issue where inactive connections lingering in
the pools caused problems for rb later on.  This is preferred
over handling potential errors elsewhere because at this point
we can be confident that the server did not actually execute
partial commands.