### PR TITLE
Ensure connections are returned back to the connection pool on error.

### DIFF
--- a/rb/clients.py
+++ b/rb/clients.py
@@ -409,8 +409,10 @@ class MappingClient(RoutingBaseClient):
                 # network is low and redis is super quick in sending.  It
                 # does not make a lot of sense to complicate things here.
                 elif event in ('read', 'close'):
-                    command_buffer.wait_for_responses(self)
-                    self._release_command_buffer(command_buffer)
+                    try:
+                        command_buffer.wait_for_responses(self)
+                    finally:
+                        self._release_command_buffer(command_buffer)
 
         if self._cb_poll and timeout is not None:
             raise TimeoutError('Did not receive all data in time.')

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,6 +1,7 @@
 import time
 import pytest
 from redis.client import Script
+from redis.exceptions import ResponseError
 from rb.cluster import Cluster
 from rb.router import UnroutableCommand
 from rb.promise import Promise
@@ -110,6 +111,37 @@ def test_simple_api(cluster):
 
     for x in xrange(10):
         assert client.get('key:%d' % x) is None
+
+
+def test_routing_client_releases_connection_on_error(cluster):
+    client = cluster.get_routing_client()
+    with pytest.raises(ResponseError):
+        client.sadd('key')
+
+    host = cluster.get_router().get_host_for_command('sadd', ['key'])
+    pool = cluster.get_pool_for_host(host)
+    assert len(pool._available_connections) == pool._created_connections
+
+
+def test_mapping_client_releases_connection_on_error(cluster):
+    client = cluster.get_routing_client().get_mapping_client()
+    client.sadd('key')
+    with pytest.raises(ResponseError):
+        client.join()
+
+    host = cluster.get_router().get_host_for_command('sadd', ['key'])
+    pool = cluster.get_pool_for_host(host)
+    assert len(pool._available_connections) == pool._created_connections
+
+
+def test_managed_mapping_client_releases_connection_on_error(cluster):
+    with pytest.raises(ResponseError):
+        with cluster.get_routing_client().map() as client:
+            client.sadd('key')
+
+    host = cluster.get_router().get_host_for_command('sadd', ['key'])
+    pool = cluster.get_pool_for_host(host)
+    assert len(pool._available_connections) == pool._created_connections
 
 
 def test_multi_keys_rejected(cluster):


### PR DESCRIPTION
This ensures that connections are released back to the connection pool when an error response is received when using `MappingClient`. Without this change, the number of established connections in the pool will continue to grow each time an error response is received until it reaches the connection pool maximum size.