### PR TITLE
ref(py3): Ensure crc32 works consistently between 2/3

### DIFF
--- a/rb/router.py
+++ b/rb/router.py
@@ -1,8 +1,7 @@
 from weakref import ref as weakref
-from binascii import crc32
 
 from rb.ketama import Ketama
-from rb.utils import text_type, bytes_type, integer_types
+from rb.utils import text_type, bytes_type, integer_types, crc32
 from rb._rediscommands import COMMANDS
 
 

--- a/rb/utils.py
+++ b/rb/utils.py
@@ -6,26 +6,45 @@ PY2 = sys.version_info[0] == 2
 
 if PY2:
     integer_types = (int, long)
-
     text_type = unicode
-
     bytes_type = str
 
     _iteritems = "iteritems"
     _itervalues = "itervalues"
 
     from itertools import izip
+
+    from binascii import crc32
 else:
     integer_types = (int,)
-
     text_type = str
-
     bytes_type = bytes
 
     izip = zip
 
     _iteritems = "items"
     _itervalues = "values"
+
+    from binascii import crc32 as _crc32
+
+    # In python3 crc32 was changed to never return a signed value, which is
+    # different from the python2 implementation. As noted in
+    # https://docs.python.org/3/library/binascii.html#binascii.crc32
+    #
+    # Note the documentation suggests the following:
+    #
+    # > Changed in version 3.0: The result is always unsigned. To generate the
+    # > same numeric value across all Python versions and platforms, use
+    # > crc32(data) & 0xffffffff.
+    #
+    # However this will not work when transitioning between versions, as the
+    # value MUST match what was generated in python 2.
+    #
+    # We can sign the return value using the following bit math to ensure we
+    # match the python2 output of crc32.
+    def crc32(*args):
+        rt = _crc32(*args)
+        return rt - ((rt & 0x80000000) <<1)
 
 
 def iteritems(d, **kw):


### PR DESCRIPTION
Tests:

python2:

```
>>> from binascii import crc32
>>> crc32('test')
-662733300
```

```
>>> from rb.utils import crc32
>>> crc32('test')
-662733300
```

python3
```
>>> from rb.utils import crc32
>>> crc32(b'test')
-662733300
```