### PR TITLE
fix(tests): Fix tests for redis >= 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ os: linux
 jobs:
   include:
     - python: 2.7
+      env: REDIS_VERSION=">=2.6,<2.11"
+    - python: 2.7
+      env: REDIS_VERSION=">=3.3,<3.4"
     - python: pypy
     - python: 3.6
+      env: REDIS_VERSION=">=2.6,<2.11"
+    - python: 3.6
+      env: REDIS_VERSION=">=3.3,<3.4"
     - python: 3.8
     - python: pypy3
     - os: osx

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import re
 import ast
+import os
 from setuptools import setup
 
 
@@ -11,6 +12,17 @@ with open("rb/__init__.py", "rb") as f:
         ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
     )
 
+install_requires = ["redis>=2.6,<3.4"]
+
+# override django version in requirements file if DJANGO_VERSION is set
+REDIS_VERSION = os.environ.get('REDIS_VERSION')
+if REDIS_VERSION:
+    install_requires = [
+        u'redis{}'.format(REDIS_VERSION)
+        if r.startswith('redis>=') else r
+        for r in install_requires
+    ]
+
 
 setup(
     name="rb",
@@ -20,7 +32,7 @@ setup(
     url="http://github.com/getsentry/rb",
     packages=["rb"],
     description="rb, the redis blaster",
-    install_requires=["redis>=2.6,<2.11"],
+    install_requires=install_requires,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
The codebase looks compatible with redis 3.x anyway, but these tests would fail. Also adds explicit tests for Might be worth adding a separate test for redis 2.10.x and redis 3.3.x