### PR TITLE
Bump version and update changelog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Rb Changelog
 ============
 
+Version 1.8
+-----------
+
+- Python 3.6 compatibility
+- Redis compatibility for versions >=2.6,<3.4
+
 Version 1.7
 -----------
 

--- a/rb/__init__.py
+++ b/rb/__init__.py
@@ -18,7 +18,7 @@ from rb.router import (
 from rb.promise import Promise
 
 
-__version__ = "1.7"
+__version__ = "1.8"
 
 __all__ = [
     # cluster


### PR DESCRIPTION
We should be good to go to have this working in python 3 now, releasing a new version so that we can bump in sentry.