### PR TITLE
upgrade(redis-py): Allow using redis-py@3.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("rb/__init__.py", "rb") as f:
         ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
     )
 
-install_requires = ["redis>=2.6,<3.4"]
+install_requires = ["redis>=2.6,<3.5,!=3.4.0"]
 
 # override django version in requirements file if DJANGO_VERSION is set
 REDIS_VERSION = os.environ.get('REDIS_VERSION')


### PR DESCRIPTION
`redis-py@3.4.1` has some important concurrency fixes around pool management and doesn't have any breaking changes. That said `3.4.0` has a bug that might potentially be breaking. So this change relaxes the version requirement but excludes the unsafe `3.4.0` version.

See the relevant changes from 3.3.11 to 3.4.1: https://github.com/andymccurdy/redis-py/blob/1a41cfd95a53a95b078084d8627be6b6fba3bb71/CHANGES#L59-L106

Needed to unblock getsentry/sentry#24235